### PR TITLE
fix TiAlert crash when alert has no matched_rules attribute

### DIFF
--- a/JIRA/app.py
+++ b/JIRA/app.py
@@ -937,7 +937,10 @@ def _format_config_time(alert_time):
 
 
 def _format_description(alert, notes=None):
-    rules = "\n** ".join(rule.name for rule in alert.matched_rules)
+    if hasattr(alert, "matched_rules"):
+        rules = "\n** ".join(rule.name for rule in alert.matched_rules)
+    else:
+        rules = "\n** ".join(p.pattern for p in alert.matched_indicator_patterns)
     entities = "\n** ".join(
         entity.entity_type
         + ": "
@@ -967,10 +970,11 @@ def _format_description(alert, notes=None):
         for indicator in alert.indicators
     )
     mitres = []
-    for rule in alert.matched_rules:
-        for matched_filter in rule.matched_filters:
-            for tech in matched_filter.mitre_technique_ids:
-                mitres.append(tech)
+    if hasattr(alert, "matched_rules"):
+        for rule in alert.matched_rules:
+            for matched_filter in rule.matched_filters:
+                for tech in matched_filter.mitre_technique_ids:
+                    mitres.append(tech)
     mitres = "\n** ".join(mitres)
     
     # 格式化notes部分


### PR DESCRIPTION
TiAlert does not have matched_rules; use matched_indicator_patterns for rules and skip MITRE extraction for TI-type alerts.

# Description

Please include a summary of the changes and/or the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

