### PR TITLE
ci: add JIRA connector release workflow and helper

### DIFF
--- a/.github/workflows/jira-release.yml
+++ b/.github/workflows/jira-release.yml
@@ -1,0 +1,55 @@
+name: "JIRA Connector Release"
+
+# Triggered by pushing a tag matching jira-v* (e.g. jira-v1.0.0).
+# Packages only the JIRA/ directory into a tarball, publishes a versioned
+# GitHub release, and refreshes the moving "jira-latest" release/tag that the
+# README download link points to.
+on:
+  push:
+    tags:
+      - 'jira-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Package and publish JIRA connector
+    runs-on: ubuntu-latest
+    env:
+      ASSET_NAME: tm-v1-jira-connector.tar.gz
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          # Tag looks like "jira-v1.0.0"; strip the "jira-v" prefix.
+          version="${GITHUB_REF_NAME#jira-v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing JIRA connector version ${version}"
+
+      - name: Package JIRA connector
+        run: |
+          # Stamp the version into the tarball so the artifact is self-describing.
+          echo "${{ steps.version.outputs.version }}" > JIRA/VERSION
+          tar -czf "${ASSET_NAME}" -C JIRA .
+          echo "Built ${ASSET_NAME}:"
+          tar -tzf "${ASSET_NAME}"
+
+      - name: Publish versioned release
+        run: |
+          gh release create "${GITHUB_REF_NAME}" "${ASSET_NAME}" \
+            --title "JIRA Connector v${{ steps.version.outputs.version }}" \
+            --notes "Trend Vision One JIRA connector v${{ steps.version.outputs.version }}. Download: ${ASSET_NAME}"
+
+      - name: Refresh jira-latest moving release
+        run: |
+          # Recreate the moving release so the stable README link always serves
+          # the newest JIRA build, independent of other connectors' releases.
+          gh release delete jira-latest --yes --cleanup-tag || true
+          gh release create jira-latest "${ASSET_NAME}" \
+            --title "JIRA Connector (latest: v${{ steps.version.outputs.version }})" \
+            --notes "Always points to the newest JIRA connector release (currently v${{ steps.version.outputs.version }})."

--- a/JIRA/README.md
+++ b/JIRA/README.md
@@ -1,5 +1,14 @@
 ## Trend Vision One™ JIRA connector
 
+#### Download
+Latest packaged release (always points to the newest build):
+- [tm-v1-jira-connector.tar.gz](https://github.com/trendmicro/tm-v1-connectors/releases/download/jira-latest/tm-v1-jira-connector.tar.gz)
+
+Extract it, then follow the Quick start below:
+```
+tar -xzf tm-v1-jira-connector.tar.gz
+```
+
 #### Prerequisites
 - [Python 3.8](https://www.python.org/downloads/) or newer.
 - JIRA API url.

--- a/JIRA/RELEASE.md
+++ b/JIRA/RELEASE.md
@@ -1,0 +1,46 @@
+# Releasing the JIRA connector
+
+This is the release runbook for the Trend Vision One JIRA connector. It is written
+so either a human or an AI agent can follow it end to end. Versioning is automatic:
+you never hand-edit a version string in any file.
+
+## How it works
+
+- Versions live in git tags shaped `jira-v<MAJOR>.<MINOR>.<PATCH>` (e.g. `jira-v1.0.0`).
+- Pushing such a tag triggers `.github/workflows/jira-release.yml`, which:
+  1. Derives the version from the tag (`jira-v1.0.0` -> `1.0.0`).
+  2. Writes `JIRA/VERSION` and packages `JIRA/` into `tm-v1-jira-connector.tar.gz`.
+  3. Publishes a versioned GitHub release for the tag.
+  4. Refreshes the moving `jira-latest` release so the README download link
+     always serves the newest build.
+- The README download link is stable and JIRA-specific:
+  `https://github.com/trendmicro/tm-v1-connectors/releases/download/jira-latest/tm-v1-jira-connector.tar.gz`
+
+## Release flow
+
+1. Land all code + doc changes on `main` first (via PR). Do NOT tag an unmerged branch.
+2. From an up-to-date `main`, run the helper — it computes the next version for you:
+   ```
+   cd JIRA
+   ./release.sh          # patch bump (default): 1.0.0 -> 1.0.1
+   ./release.sh minor    # 1.0.1 -> 1.1.0
+   ./release.sh major    # 1.1.0 -> 2.0.0
+   ./release.sh 2.3.4    # explicit version, if ever needed
+   ```
+   The script fetches tags, finds the highest `jira-v*`, bumps it, confirms, then
+   pushes the new tag. First-ever release starts at `1.0.0`.
+3. Watch the run: https://github.com/trendmicro/tm-v1-connectors/actions
+4. Verify the release and the download link resolve:
+   - Versioned: `https://github.com/trendmicro/tm-v1-connectors/releases/tag/jira-v<version>`
+   - Latest link (README): downloads `tm-v1-jira-connector.tar.gz`
+
+## Choosing the bump
+
+- `patch` — bug fix only, no behavior change (default).
+- `minor` — backward-compatible feature or config addition.
+- `major` — breaking change to config or behavior.
+
+## Notes
+
+- The `jira-latest` link 404s until the first `jira-v*` tag is published; that is expected.
+- The workflow packages only `JIRA/`; other connectors in this monorepo are unaffected.

--- a/JIRA/release.sh
+++ b/JIRA/release.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Release helper for the Trend Vision One JIRA connector.
+#
+# Auto-computes the next version from existing "jira-v*" tags, creates the tag,
+# and pushes it. Pushing the tag triggers .github/workflows/jira-release.yml,
+# which packages JIRA/ and publishes the GitHub release.
+#
+# Usage:
+#   ./release.sh            # bump patch  (jira-v1.0.0 -> jira-v1.0.1)
+#   ./release.sh minor      # bump minor  (jira-v1.0.1 -> jira-v1.1.0)
+#   ./release.sh major      # bump major  (jira-v1.1.0 -> jira-v2.0.0)
+#   ./release.sh 2.3.4       # set an explicit version
+#
+set -euo pipefail
+
+TAG_PREFIX="jira-v"
+BUMP="${1:-patch}"
+
+# Ensure local tags are up to date with the remote before computing the next one.
+git fetch --tags --quiet
+
+# Find the highest existing jira-v* version (empty if this is the first release).
+latest="$(git tag -l "${TAG_PREFIX}*" | sed "s/^${TAG_PREFIX}//" | sort -V | tail -n1)"
+
+if [[ "${BUMP}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Explicit version supplied.
+  next="${BUMP}"
+else
+  if [[ -z "${latest}" ]]; then
+    # No prior release: start at 1.0.0 regardless of bump type.
+    next="1.0.0"
+  else
+    IFS='.' read -r major minor patch <<<"${latest}"
+    case "${BUMP}" in
+      major) major=$((major + 1)); minor=0; patch=0 ;;
+      minor) minor=$((minor + 1)); patch=0 ;;
+      patch) patch=$((patch + 1)) ;;
+      *) echo "Unknown bump type: ${BUMP} (use major|minor|patch or an explicit X.Y.Z)" >&2; exit 1 ;;
+    esac
+    next="${major}.${minor}.${patch}"
+  fi
+fi
+
+tag="${TAG_PREFIX}${next}"
+
+if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+  echo "Tag ${tag} already exists. Aborting." >&2
+  exit 1
+fi
+
+echo "Current latest: ${latest:-<none>}"
+echo "New release   : ${tag}"
+read -r -p "Create and push ${tag}? [y/N] " confirm
+if [[ "${confirm}" != "y" && "${confirm}" != "Y" ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+git tag -a "${tag}" -m "JIRA connector ${next}"
+git push origin "${tag}"
+
+echo "Pushed ${tag}. GitHub Actions is now building and publishing the release."
+echo "Track it: https://github.com/trendmicro/tm-v1-connectors/actions"


### PR DESCRIPTION
Add tag-triggered GitHub Actions workflow that packages only the JIRA/ directory into tm-v1-jira-connector.tar.gz, publishes a versioned release, and refreshes a moving jira-latest release for a stable README download link.

Add release.sh to auto-compute the next jira-v* version and push the tag, and RELEASE.md documenting the flow for human or AI operators. Version is derived from the tag, so no version string is hand-edited.

# Description

Please include a summary of the changes and/or the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

