### PR TITLE
fix(jira): on-prem connector upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .venv/
 .idea/
 .cache
+__pycache__/
+*.pyc

--- a/JIRA/README.md
+++ b/JIRA/README.md
@@ -1,88 +1,206 @@
 ## Trend Vision One™ JIRA connector
 
-#### Download
+A standalone poller that keeps Trend Vision One workbench alerts and JIRA issues
+in sync. It creates a JIRA issue for each new workbench alert and keeps the alert
+status and the issue status aligned in both directions.
+
+### Contents
+- [How it works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Supported JIRA versions](#supported-jira-versions)
+- [Download](#download)
+- [Quick start](#quick-start)
+- [Authentication](#authentication)
+- [Configuration](#configuration)
+  - [General](#general)
+  - [Vision One](#vision-one)
+  - [JIRA](#jira)
+  - [Field mapping](#field-mapping-jira-fields---static-values-or-vision-one-attributes)
+  - [Status mapping](#status-mapping-jira-status---vision-one-alert-status)
+- [Full config example](#full-config-example)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+### How it works
+Every `poll_time` seconds the connector:
+
+1. Fetches workbench alerts from Vision One in the configured time window.
+2. For a **new** alert (not seen before), creates a JIRA issue with the mapped
+   fields and description, attaches the raw alert JSON, and writes a note back
+   to the Vision One alert with the issue key.
+3. For a **known** alert (already has an issue), compares the JIRA status and the
+   Vision One alert status and, if they differ, syncs the side that changed
+   **last** (by last-updated timestamp):
+   - JIRA changed more recently -> update the Vision One alert status.
+   - Vision One changed more recently -> transition the JIRA issue.
+
+Processed alerts are tracked in a local `.cache` file (`alertId:issueKey`) to
+avoid duplicate issues.
+
+Status sync is driven by the Vision One Alert **status** (`Open`, `In Progress`,
+`Closed`) - the workbench alert lifecycle status shown in the Vision One console.
+The deprecated *investigation status* is not used: a closed alert reports an
+investigation *result* (e.g. `True Positive`), which is a separate field.
+
+### Prerequisites
+- [Python 3.8](https://www.python.org/downloads/) or newer.
+- JIRA base URL and credentials (see [Authentication](#authentication)).
+- Trend Vision One API URL.
+- Trend Vision One API token with permissions:
+  - View, filter, and search
+  - Modify alert details
+
+### Supported JIRA versions
+Targets **on-premise JIRA (Server / Data Center) 9.x and newer** via the JIRA
+REST API v2 (`/rest/api/2/...`). JIRA Cloud is also supported using Cloud
+API-token (basic) authentication.
+
+### Download
 Latest packaged release (always points to the newest build):
 - [tm-v1-jira-connector.tar.gz](https://github.com/trendmicro/tm-v1-connectors/releases/download/jira-latest/tm-v1-jira-connector.tar.gz)
 
-Extract it, then follow the Quick start below:
+Extract it:
 ```
 tar -xzf tm-v1-jira-connector.tar.gz
 ```
 
-#### Prerequisites
-- [Python 3.8](https://www.python.org/downloads/) or newer.
-- JIRA API url.
-- JIRA username/token.
-- Trend Vision One API url. 
-- Trend Vision One API token with permissions: 
-  - View, filter, and search
-  - Modify alert details
+### Quick start
+1. Install:
+   ```
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+2. Configure: edit [config.yml](config.yml) (see [Configuration](#configuration)).
+3. Run:
+   ```
+   python3 app.py
+   ```
+   The connector runs continuously, polling every `poll_time` seconds. Run it
+   under a process manager (systemd, supervisor, ...) for unattended use.
 
-#### Features
-- Create issue from Trend Vision One workbench alerts.
-- Add issue number to the workbench alert notes.
-- Update issue based on workbench alert status/jira status mapping.
-- Map issue fields to static data/vision one attributes.
- 
-#### Quick start
-- Installation:
-  ```
-  python3 -m venv .venv
-  source .venv/bin/activate
-  pip install --upgrade pip
-  pip install -r requirements.txt
-  ```
-- Configuration:
-  - Edit [config.yml](config.yml).
+### Authentication
+The connector auto-selects the auth scheme from `jira.username`:
 
-- Start application:
-  ```
-  python3 app.py
-  ```
+| Deployment             | `jira.username`       | `jira.token`                | Header sent      |
+|:-----------------------|:----------------------|:----------------------------|:-----------------|
+| On-premise (Server/DC) | leave **empty**       | Personal Access Token (PAT) | `Bearer <token>` |
+| Cloud                  | account email address | Cloud API token             | `Basic <base64>` |
 
-#### YAML Configuration
-The configuration of this project is based on YAML config file [config.yml](config.yml).
-##### General
-| yaml           | description                                                                                  |
-|:---------------|:---------------------------------------------------------------------------------------------|
-| project        | JIRA Project ID or key.                                                                      |
-| issue_type     | JIRA Issue type ID or name.                                                                  |
-| summary_prefix | (Optional) JIRA Issue summary prefix.                                                        |
-| poll_time      | Skip closed alerts in Vision One, else create a new JIRA and re-open the alert.              |
-| start_time     | (Optional) Alerts fetch start time (UTC timezone), defaults to the time the request is made. |
-| end_time       | (Optional) Alerts fetch end time (UTC timezone), defaults to the time the request is made.   |
-| skip_closed    | Skip closed alerts in Vision One, else create a new JIRA and re-open the alert.              |
-| debug          | Enable debug logging.                                                                        |
-| to_file        | Enable logging to file instead of stdout.                                                    |
-| filename       | Log filename.                                                                                |
-| file_size      | Log file max size in MB.                                                                     |
-| file_count     | Log files rotation count.                                                                    |
-##### Vision One
-| yaml     | description           |
-|:---------|:----------------------|
-| v1.url   | Vision One API URL.   |
-| v1.token | Vision One API Token. | 
+Vision One authenticates with an API token (`v1.token`).
 
-##### JIRA
-| yaml          | description                                                                                                 |
-|:--------------|:------------------------------------------------------------------------------------------------------------|
-| jira.url      | JIRA URL.                                                                                                   |
-| jira.username | JIRA Cloud Username (User email address associated to the API Token), If using JIRA On-premise leave empty. |
-| jira.token    | JIRA Cloud API Token or On-premise Personal Authentication Token.                                           |
+> The auth mode also changes how user fields (`reporter`, `assignee`) are sent:
+> on-premise uses the JIRA **username**, Cloud uses the **accountId**. See
+> [Field mapping](#field-mapping-jira-fields---static-values-or-vision-one-attributes).
 
-##### Mapping: [JIRA issue fields] to [Static data] OR [Vision One attributes mapping]
-- Map JIRA field to: static values, or to Vision One alert attributes returned by [Get alert details API](https://automation.trendmicro.com/xdr/api-v3#tag/Workbench/paths/~1v3.0~1workbench~1alerts/get).
-- (Optional) mapping available to map multiple JIRA values with Vision One attributes values. (i.e: priority 'P3' in JIRA mapped to Vision One severity 'low').
+### Configuration
+All configuration is in the YAML file [config.yml](config.yml).
 
-| yaml               | description                                                                                                                                           |
-|:-------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------|
-| fields[].name      | JIRA field name or key (i.e: priority, label, customfield_12345, ...).                                                                                |
-| fields[].value([]) | JIRA field value(s) (i.e: 2345, Option 1, email@address.com, ...) or Vision One attribute (i.e: alert.id, alert.alert_provider, alert.severity, ...). |
-| fields[].mapping   | (Optional) JIRA-Vision one field value mapping (i.e: P3: low).                                                                                        |
+#### General
+| yaml           | description                                                                                   |
+|:---------------|:----------------------------------------------------------------------------------------------|
+| project        | JIRA Project ID or key.                                                                        |
+| issue_type     | JIRA Issue type ID or name (e.g. `Bug`).                                                       |
+| summary_prefix | (Optional) Prefix prepended to the issue summary. Leave empty to omit.                         |
+| poll_time      | Seconds to wait between polling cycles.                                                        |
+| start_time     | (Optional) Alerts fetch start time, UTC (e.g. `2025-08-07 08:20:00`). Defaults to 24h before the request. Max lookback 30 days. |
+| end_time       | (Optional) Alerts fetch end time, UTC. Defaults to the time the request is made.               |
+| skip_closed    | `true`: ignore alerts already `Closed` in Vision One. `false`: create an issue and re-open them. |
+| debug          | Enable debug logging.                                                                          |
+| to_file        | Log to a rotating file instead of stdout.                                                      |
+| filename       | Log filename (when `to_file`).                                                                 |
+| file_size      | Log file max size in MB.                                                                        |
+| file_count     | Number of rotated log files to keep.                                                           |
 
-##### Mapping: [JIRA issue status] to [Vision One Alert investigation status]
-| yaml                | description                                                    |
-|:--------------------|:---------------------------------------------------------------|
-| status[].name       | JIRA status name (i.e: To Do, Done, ...).                      |
-| status[].inv        | Vision One Alert investigation status (i.e: New, Closed, ...). |
-| status[].fields([]) | (Optional) JIRA field name/value mapping as described above.   |
+#### Vision One
+| yaml     | description         |
+|:---------|:--------------------|
+| v1.url   | Vision One API URL. |
+| v1.token | Vision One API token. |
+
+#### JIRA
+| yaml          | description                                                                        |
+|:--------------|:-----------------------------------------------------------------------------------|
+| jira.url      | JIRA base URL.                                                                      |
+| jira.username | Cloud: the account email tied to the API token. On-premise: **leave empty**.       |
+| jira.token    | Cloud API token, or on-premise Personal Access Token (PAT).                         |
+
+#### Field mapping: [JIRA fields] -> [static values] OR [Vision One attributes]
+Map a JIRA field to a static value, or to a Vision One alert attribute returned
+by the [Get alert details API](https://automation.trendmicro.com/xdr/api-v3#tag/Workbench/paths/~1v3.0~1workbench~1alerts/get)
+(prefix with `alert.`, e.g. `alert.id`, `alert.severity`, `alert.alert_provider`).
+
+| yaml               | description                                                                                                                                     |
+|:-------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|
+| fields[].name      | JIRA field name or key (e.g. `priority`, `labels`, `customfield_12345`).                                                                       |
+| fields[].value([]) | A static value, or a Vision One attribute (`alert.*`). May be a list. For user fields (`reporter`, `assignee`) use the JIRA **username** on-premise, the **accountId** on Cloud. |
+| fields[].mapping   | (Optional) Translate a Vision One value to a JIRA value. Written as `JIRA_value: vision_one_value` (e.g. `High: high`).                        |
+
+Notes:
+- Any JIRA field that is **required** for your issue type must be present here
+  (e.g. `reporter` is often required). Missing required fields fail issue creation.
+- `mapping` values must match the exact Vision One attribute value. Severity
+  values are lowercase: `critical`, `high`, `medium`, `low`.
+
+#### Status mapping: [JIRA status] -> [Vision One Alert status]
+This table drives the two-way status sync.
+
+| yaml                | description                                                                                                                                    |
+|:--------------------|:---------------------------------------------------------------------------------------------------------------------------------------------|
+| status[].name       | JIRA status name, exactly as it appears in your workflow (case-insensitive).                                                                   |
+| status[].inv        | Vision One Alert status: `Open`, `In Progress`, or `Closed`. The legacy value `New` is accepted as an alias for `Open`.                        |
+| status[].inv_result | (Optional) Vision One investigation result set on the JIRA -> Vision One sync. **Required when `inv` is `Closed`** (Vision One rejects closing an alert without a result). One of: `No Findings`, `Noteworthy`, `True Positive`, `False Positive`, `Benign True Positive`. If omitted, an `investigationResult` entry under `fields` is used as a fallback. |
+| status[].fields([]) | (Optional) Extra JIRA fields set during the JIRA transition (Vision One -> JIRA direction), e.g. a resolution when closing. Same shape as [Field mapping](#field-mapping-jira-fields---static-values-or-vision-one-attributes). |
+
+**Important - the mapping must cover your whole workflow:**
+
+- Vision One has exactly three alert statuses (`Open`, `In Progress`, `Closed`).
+  Map **each of the three** so the Vision One -> JIRA direction always has a
+  target JIRA status.
+- List **every JIRA status an issue can be in**, not just three. If an issue sits
+  in an unmapped status (e.g. a `Selected for Development` or a review column your
+  workflow adds), the sync for that issue is skipped and logged as
+  *"JIRA status not mapped"*. Add every reachable status.
+- The JIRA status names must match your workflow. The bundled sample uses the
+  generic `To Do` / `In Progress` / `Done`; a real workflow often differs
+  (localized names, extra columns, a service-desk workflow). Adjust to yours.
+- Avoid mapping **more than one** JIRA status to the same `inv` value. The
+  Vision One -> JIRA direction transitions to the **first** matching entry, so
+  duplicates make that direction ambiguous.
+- When closing (`inv: Closed`), provide `inv_result`. If your close transition
+  screen requires a resolution, also add it under `fields`.
+
+Worked example - a workflow with an extra `Selected for Development` column and a
+`Backlog` start state, all mapped:
+```yaml
+status:
+  - name: Backlog
+    inv: Open
+  - name: Selected for Development
+    inv: In Progress
+  - name: In Progress
+    inv: In Progress            # NOTE: two JIRA statuses -> In Progress.
+                                # V1 -> JIRA will pick "Selected for Development"
+                                # (first match). Prefer one JIRA status per inv.
+  - name: Done
+    inv: Closed
+    inv_result: True Positive
+    fields:
+      - name: Resolution        # only if your close transition screen asks for it
+        value: Done
+```
+
+### Full config example
+See [config.yml](config.yml) for a complete, commented sample.
+
+### Troubleshooting
+| Symptom (log / API error) | Cause | Fix |
+|:--------------------------|:------|:----|
+| Vision One error `3090003` "Unable to process the request" on status update | Old `pytmv1`; incompatible alert-status API | Use the shipped `requirements.txt` (`pytmv1~=0.11.0`). |
+| `JIRA status not mapped` / `Vision One ... status not mapped` | An in-use JIRA status (or an alert status) is missing from `status:` | Add every reachable JIRA status; map all three Vision One statuses. See [Status mapping](#status-mapping-jira-status---vision-one-alert-status). |
+| Closing does not sync / "requires an investigation result" | `inv: Closed` without `inv_result` | Add `inv_result` (e.g. `True Positive`) to the Closed entry. |
+| Issue creation fails on `reporter`/`assignee` | Wrong user identifier for the deployment | On-premise: leave `jira.username` empty and use the JIRA **username** as the field value. Cloud: use the **accountId**. |
+| `... field cannot be set. It is not on the appropriate screen` | A `fields` entry (e.g. `Resolution`) is not on the transition screen | Add the field to the JIRA transition screen, or remove it from `fields`. |
+| Issue creation blocked by license | JIRA license invalid/expired | Renew the JIRA license. |

--- a/JIRA/app.py
+++ b/JIRA/app.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import dataclasses
 import datetime
 import logging
@@ -12,7 +13,7 @@ from typing import Any, Dict, List, Union
 
 import pytmv1
 import yaml
-from pytmv1 import EntityType, InvestigationStatus, ResultCode
+from pytmv1 import AlertStatus, EntityType, InvestigationResult, ResultCode
 from requests import Request, Session
 
 ALERT_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
@@ -138,7 +139,11 @@ def _validate_keys(fields, status):
     error = False
     configs = [
         {"config": fields, "req": ("name", "value"), "optional": ("mapping",)},
-        {"config": status, "req": ("name", "inv"), "optional": ("fields",)},
+        {
+            "config": status,
+            "req": ("name", "inv"),
+            "optional": ("fields", "inv_result"),
+        },
     ]
     for cfg in configs:
         valid_keys = [*cfg["req"], *cfg["optional"]]
@@ -334,15 +339,20 @@ class App:
         return body
 
     def _fields_to_body(self, alert, fields):
-        copy = fields.copy()
-        _map_v1_fields_value(alert, copy)
+        # Deep copy so resolving Vision One attributes (alert.*) into concrete
+        # values does not mutate the shared config field dicts. A shallow copy
+        # overwrote the source "value" (e.g. "alert.id") with the first alert's
+        # resolved value; subsequent alerts then failed the "alert." prefix
+        # check and reused stale values, corrupting labels/priority.
+        fields = copy.deepcopy(fields)
+        _map_v1_fields_value(alert, fields)
         return {
             field.get("key"): (
                 [self._field_to_body(field, val) for val in field.get("value")]
                 if isinstance(field.get("value"), list)
                 else self._field_to_body(field, field.get("value"))
             )
-            for field in copy
+            for field in fields
         }
 
 
@@ -354,7 +364,13 @@ class App:
         if field_type == "number":
             return int(value)
         if field_type == "user":
-            return {"accountId": self._jira_user_acc_name(field.get("key"), value)}
+            user_ref = self._jira_user_acc_name(field.get("key"), value)
+            # JIRA Cloud identifies users by accountId (GDPR strict mode);
+            # on-premise (Server/Data Center) uses the username via "name".
+            # Mirror the auth-mode switch in _send: a configured username means
+            # Cloud, an empty one means on-premise.
+            ref_key = "accountId" if self.cfg.jira.get("username") else "name"
+            return {ref_key: user_ref}
         if isinstance(value, int) or str(value).isdigit():
             return {"id": str(value)}
         return {("name" if schema.get("system") else "value"): value}
@@ -388,7 +404,7 @@ class App:
     def _update_issue(self, alert):
         log.debug("Found in cache, checking if update required")
         jira_status = self._jira_status(alert)
-        v1_status = alert.investigation_status
+        v1_status = alert.status
         self._validate_curr_statuses(jira_status, v1_status)
         if self._is_status_equal(jira_status, v1_status):
             log.debug(
@@ -409,7 +425,7 @@ class App:
         if last_jira_update > last_v1_update:
             log.debug("JIRA updated after Vision One")
             self._v1_edit_status(
-                alert, self._get_config_status_by(jira_status, "key")["inv_st"]
+                alert, self._get_config_status_by(jira_status, "key")
             )
             return
         log.debug("Vision One updated after JIRA")
@@ -418,7 +434,14 @@ class App:
         json = {
             "transition": {"id": transition["id"]},
         }
-        fields = config_status.get("fields", [])
+        # "investigationResult" is a Vision One concept used for the JIRA -> V1
+        # direction (see _resolve_inv_result); it is not a JIRA field, so keep it
+        # out of the JIRA transition body.
+        fields = [
+            fi
+            for fi in config_status.get("fields", [])
+            if str(fi.get("name")).lower() != _INV_RESULT_KEY
+        ]
         if fields:
             if next(filter(lambda fi: not fi.get("schema"), fields), None):
                 _map_fields_metadata(fields, transition["fields"])
@@ -428,7 +451,7 @@ class App:
     def _jira_create_issue(self, alert):
         log.info("Creating JIRA issue")
 
-        # 获取alert的notes
+        # Fetch the alert's notes.
         notes = []
         try:
             response = self.v_client.note.consume(
@@ -585,8 +608,8 @@ class App:
         return _filter_jira_transition(response.json()["transitions"], status)
 
     def _jira_user_acc_name(self, field, value):
-        # 移除使用 "username" 查询参数的 JIRA 用户搜索 API 调用
-        # 这是为了适应 JIRA Cloud 的 GDPR 严格模式
+        # Removed the JIRA user-search API call that used the "username" query
+        # parameter, to comply with JIRA Cloud GDPR strict mode.
         log.debug(
             "Directly using JIRA user ID from config for field: %s, value: %s", field, value
         )
@@ -606,12 +629,24 @@ class App:
             raise RuntimeError
         log.info("Created Vision One note: %s", response.response.note_id)
 
-    def _v1_edit_status(self, alert, status):
-        log.debug("Editing Vision One alert status")
+    def _v1_edit_status(self, alert, config_status):
+        # pytmv1 >= 0.9 changed update_status to
+        # (alert_id, etag, status, inv_result, inv_status). ETag is the
+        # If-Match header, status is the AlertStatus body value. Passing them
+        # positionally in the old (alert_id, status, etag) order swapped the two
+        # and caused Vision One error 3090003.
+        status = config_status["inv_st"]
+        inv_result = _resolve_inv_result(config_status, status)
+        log.debug(
+            "Editing Vision One alert status to: %s (result: %s)",
+            status.value,
+            inv_result.value if inv_result else None,
+        )
         response = self.v_client.alert.update_status(
             alert.id,
-            status,
             self._v1_etag(alert),
+            status=status,
+            inv_result=inv_result,
         )
         log.debug("Received response from Vision One: %s", response)
         if ResultCode.SUCCESS != response.result_code:
@@ -653,7 +688,7 @@ class App:
                 alert_list.append(al)
                 if al.id in self.cache
                 or not self.cfg.skip_closed
-                or al.investigation_status != InvestigationStatus.CLOSED
+                or al.status != AlertStatus.CLOSED
                 else None
             ),
             self.start_time,
@@ -746,12 +781,12 @@ def _map_statuses_metadata(statuses, jira_statuses):
             ),
             None,
         )
-        investigation_status = _get_investigation_status(status["inv"])
+        alert_status = _get_alert_status(status["inv"])
         if matched_status:
             status["id"] = matched_status[0]
             status["key"] = matched_status[1]
-        if investigation_status:
-            status["inv_st"] = investigation_status
+        if alert_status:
+            status["inv_st"] = alert_status
     _validate_statuses(statuses, jira_statuses)
 
 
@@ -771,7 +806,7 @@ def _validate_statuses(statuses, jira_statuses):
             log.error(
                 "Vision One Status mapping error\nVision One Status not found: %s\nValid values: %s",
                 [st["inv"] for st in inv_status_not_found],
-                [inv.value for inv in InvestigationStatus],
+                [st.value for st in AlertStatus] + ["New (alias of Open)"],
             )
         raise ValueError
 
@@ -790,14 +825,78 @@ def _get_conf_field_by_name(config_fields, jira_field):
     )
 
 
-def _get_investigation_status(value):
+# Legacy config values that predate the AlertStatus vocabulary. Vision One
+# retired the "New" investigation status; the current alert lifecycle uses
+# AlertStatus (Open, In Progress, Closed). Map "New" to Open so existing
+# customer configurations keep working without an edit.
+_ALERT_STATUS_ALIASES = {"new": AlertStatus.OPEN}
+
+# Reserved status-mapping field name: a Vision One investigation result carried
+# in a status "fields" block. Used for the JIRA -> V1 direction, never sent to
+# JIRA as a field. Compared lower-cased.
+_INV_RESULT_KEY = "investigationresult"
+
+
+def _get_alert_status(value):
+    """Resolve a config ``inv`` value to a Vision One AlertStatus.
+
+    Accepts current AlertStatus values (Open, In Progress, Closed) plus the
+    legacy "New" alias for Open, keeping pre-breakage configs valid.
+    """
+    normalized = str(value).lower()
+    if normalized in _ALERT_STATUS_ALIASES:
+        return _ALERT_STATUS_ALIASES[normalized]
     return next(
-        filter(
-            lambda inv: inv.lower() == value.lower(),
-            InvestigationStatus,
-        ),
+        filter(lambda st: st.value.lower() == normalized, AlertStatus),
         None,
     )
+
+
+def _get_investigation_result(value):
+    return next(
+        filter(lambda ir: ir.value.lower() == str(value).lower(), InvestigationResult),
+        None,
+    )
+
+
+def _resolve_inv_result(config_status, status):
+    """Resolve the InvestigationResult to send when syncing JIRA -> Vision One.
+
+    Reads an explicit ``inv_result`` key, else falls back to an
+    ``investigationResult`` entry in the status ``fields`` (kept for backward
+    compatibility with existing configs). Vision One rejects closing an alert
+    without a result, so a missing result on a Closed transition is an error.
+    """
+    raw = config_status.get("inv_result")
+    if not raw:
+        field = next(
+            (
+                fi
+                for fi in config_status.get("fields", [])
+                if str(fi.get("name")).lower() == _INV_RESULT_KEY
+            ),
+            None,
+        )
+        raw = field.get("value") if field else None
+    if not raw:
+        if status == AlertStatus.CLOSED:
+            log.error(
+                "Closing a Vision One alert requires an investigation result. "
+                "Add 'inv_result' (or an 'investigationResult' field) to the "
+                "status mapping. Valid values: %s",
+                [ir.value for ir in InvestigationResult],
+            )
+            raise ValueError
+        return None
+    result = _get_investigation_result(raw)
+    if not result:
+        log.error(
+            "Vision One investigation result not valid\nValue: %s\nValid values: %s",
+            raw,
+            [ir.value for ir in InvestigationResult],
+        )
+        raise ValueError
+    return result
 
 
 def _map_v1_fields_value(alert, fields):
@@ -936,77 +1035,85 @@ def _format_config_time(alert_time):
     return None
 
 
+# Cap per description section so a noisy alert (e.g. a scanner dumping hundreds
+# of duplicate indicators) does not produce an unbounded JIRA description.
+_MAX_DESC_ITEMS = 50
+
+
+def _enum_val(value):
+    """Render an enum by its API value ("low"), not its member repr ("Severity.LOW")."""
+    return value.value if isinstance(value, Enum) else str(value)
+
+
+def _format_ref(value):
+    """Format an entity/indicator value that may be a plain string or a HostInfo."""
+    if isinstance(value, str):
+        return value
+    text = value.name
+    if getattr(value, "guid", None):
+        text += f" ({value.guid})"
+    if getattr(value, "ips", None):
+        text += " - " + ",".join(value.ips)
+    return text
+
+
+def _dedupe_cap(items):
+    """Drop duplicates (order-preserving) and cap length with an explicit note."""
+    unique = list(dict.fromkeys(items))
+    if len(unique) > _MAX_DESC_ITEMS:
+        omitted = len(unique) - _MAX_DESC_ITEMS
+        unique = unique[:_MAX_DESC_ITEMS] + [f"... ({omitted} more omitted)"]
+    return unique
+
+
 def _format_description(alert, notes=None):
     if hasattr(alert, "matched_rules"):
-        rules = "\n** ".join(rule.name for rule in alert.matched_rules)
+        rule_names = [rule.name for rule in alert.matched_rules]
     else:
-        rules = "\n** ".join(p.pattern for p in alert.matched_indicator_patterns)
+        rule_names = [p.pattern for p in alert.matched_indicator_patterns]
+    rules = "\n** ".join(_dedupe_cap(rule_names))
     entities = "\n** ".join(
-        entity.entity_type
-        + ": "
-        + (
-            entity.entity_value
-            if isinstance(entity.entity_value, str)
-            else entity.entity_value.name
-            + " ("
-            + entity.entity_value.guid
-            + ") - "
-            + ",".join(entity.entity_value.ips)
+        _dedupe_cap(
+            [
+                f"{_enum_val(entity.entity_type)}: {_format_ref(entity.entity_value)}"
+                for entity in alert.impact_scope.entities
+            ]
         )
-        for entity in alert.impact_scope.entities
     )
     indicators = "\n** ".join(
-        indicator.type
-        + ": "
-        + (
-            indicator.value
-            if isinstance(indicator.value, str)
-            else indicator.value.name
-            + " ("
-            + indicator.value.guid
-            + ") - "
-            + ",".join(indicator.value.ips)
+        _dedupe_cap(
+            [
+                f"{_enum_val(indicator.type)}: {_format_ref(indicator.value)}"
+                for indicator in alert.indicators
+            ]
         )
-        for indicator in alert.indicators
     )
-    mitres = []
+    mitre_ids = []
     if hasattr(alert, "matched_rules"):
         for rule in alert.matched_rules:
             for matched_filter in rule.matched_filters:
-                for tech in matched_filter.mitre_technique_ids:
-                    mitres.append(tech)
-    mitres = "\n** ".join(mitres)
-    
-    # 格式化notes部分
-    notes_section = ""
+                mitre_ids.extend(matched_filter.mitre_technique_ids)
+    mitres = "\n** ".join(_dedupe_cap(mitre_ids))
+    description = (
+        f"*Summary*\n\n* Detected by: XDR\n* Severity: {_enum_val(alert.severity)}\n"
+        f"* Score: {alert.score}\n\n\n"
+        f"*Event Details*\n\n* Vision One Model: {alert.model}\n* Rules\n** {rules}\n"
+        f"* Vision One Alert Highlights:\n** {entities}\n"
+        f"* Vision One Alert Indicators\n** {indicators}\n"
+        f"* MITRE ATT&CK:\n** {mitres}\n"
+        f"* Vision One Alert Link:\n** {alert.workbench_link}"
+    )
     if notes:
-        formatted_notes = "\n** ".join(notes)
-        #notes_section = f"*Alert Notes:\n** {formatted_notes}"
-    
-        return (
-            f"*Summary*\n\n* Detected by: XDR\n* Severity: {alert.severity}\n* Score: {alert.score}\n\n\n"
-            f"*Event Details*\n\n* Vision One Model: {alert.model}\n* Rules\n** {rules}\n"
-            f"* Vision One Alert Highlights:\n** {entities}\n"
-            f"* Vision One Alert Indicators\n** {indicators}\n"
-            f"* MITRE ATT&CK:\n** {mitres}\n"
-            f"* Vision One Alert Link:\n** {alert.workbench_link}\n"
-            f"* Alert Notes:\n** {formatted_notes}"
-        )
-    else:
-        return (
-            f"*Summary*\n\n* Detected by: XDR\n* Severity: {alert.severity}\n* Score: {alert.score}\n\n\n"
-            f"*Event Details*\n\n* Vision One Model: {alert.model}\n* Rules\n** {rules}\n"
-            f"* Vision One Alert Highlights:\n** {entities}\n"
-            f"* Vision One Alert Indicators\n** {indicators}\n"
-            f"* MITRE ATT&CK:\n** {mitres}\n"
-            f"* Vision One Alert Link:\n** {alert.workbench_link}"
-        )
+        description += "\n* Alert Notes:\n** " + "\n** ".join(notes)
+    return description
 
 
 def _format_summary(prefix, alert):
     host_entities = _format_host_entities(alert)
     if len(host_entities) > 0:
-        value = host_entities[0].entity_value.name
+        host_value = host_entities[0].entity_value
+        # Summary wants only the host name, not the guid/ip detail.
+        value = host_value if isinstance(host_value, str) else host_value.name
     else:
         value = "Container/Cloud"
     return (

--- a/JIRA/config.yml
+++ b/JIRA/config.yml
@@ -8,8 +8,10 @@ summary_prefix: synced
 # Workbench alerts configuration
 # Poll time in seconds
 poll_time: 15
-# Workbench alerts retrieval start time (UTC timezone),
-# If empty, defaults to 24 hours before the request is made.
+# Workbench alerts retrieval start time (UTC timezone).
+# Accepts a YAML timestamp (e.g. 2025-08-07 08:20:00); it is sent to Vision One
+# in ISO 8601 form (2025-08-07T08:20:00Z). If empty, defaults to 24 hours
+# before the request is made.
 start_time: 2025-08-07 08:20:00
 # Workbench alerts retrieval end time (UTC timezone),
 # If empty, defaults to the time the request is made.
@@ -58,24 +60,34 @@ fields:
       - alert.id
   - name: priority
     value: alert.severity
+    # Left = JIRA priority name (must exist in your JIRA), right = Vision One
+    # severity (critical, high, medium, low). Adjust the JIRA names to match
+    # your instance.
     mapping:
-      Lowest: low
-      Low: medium
-      High: high
       Highest: critical
+      High: high
+      Medium: medium
+      Low: low
 
-## JIRA issue status to Vision One Alert investigation status mapping
+## JIRA issue status to Vision One Alert status mapping
 status:
   # name: JIRA status name
-  # inv: Vision One Alert investigation status
-  # fields: (Optional) extra fields required to be set during the transition,
-  # for example when closing an issue, engineer resolution is required.
+  # inv: Vision One Alert status. Valid values: Open, In Progress, Closed.
+  #      The legacy value "New" is accepted as an alias for "Open".
+  # inv_result: (Optional) Vision One investigation result set when syncing
+  #      JIRA -> Vision One. Required when inv is "Closed" (Vision One rejects
+  #      closing an alert without a result). Valid values:
+  #      No Findings, Noteworthy, True Positive, False Positive,
+  #      Benign True Positive.
+  # fields: (Optional) extra JIRA fields set during the JIRA transition
+  #      (Vision One -> JIRA direction), e.g. a resolution when closing.
   - name: To Do
-    inv: New
+    inv: Open
   - name: In Progress
     inv: In Progress
   - name: Done
     inv: Closed
+    inv_result: True Positive
     fields:
       - name: Resolution
         value: Done

--- a/JIRA/requirements.txt
+++ b/JIRA/requirements.txt
@@ -1,3 +1,3 @@
-pytmv1~=0.8.7
+pytmv1~=0.11.0
 pyyaml
 requests

--- a/JIRA/test_app.py
+++ b/JIRA/test_app.py
@@ -1,0 +1,151 @@
+"""Regression tests for the Vision One JIRA connector status sync.
+
+Run from the JIRA/ directory so ``app.py`` can load ``config.yml`` at import:
+
+    cd JIRA && python3 -m pytest test_app.py
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pytmv1 import AlertStatus, InvestigationResult, ResultCode, Severity
+
+import app
+
+
+def test_get_alert_status_accepts_current_and_legacy_values():
+    assert app._get_alert_status("Open") == AlertStatus.OPEN
+    assert app._get_alert_status("In Progress") == AlertStatus.IN_PROGRESS
+    assert app._get_alert_status("Closed") == AlertStatus.CLOSED
+    # Legacy "New" must alias to Open so pre-breakage configs keep working.
+    assert app._get_alert_status("New") == AlertStatus.OPEN
+    assert app._get_alert_status("new") == AlertStatus.OPEN
+    assert app._get_alert_status("Bogus") is None
+
+
+def test_get_investigation_result():
+    assert app._get_investigation_result("True Positive") == InvestigationResult.TRUE_POSITIVE
+    assert app._get_investigation_result("benign true positive") == (
+        InvestigationResult.BENIGN_TRUE_POSITIVE
+    )
+    assert app._get_investigation_result("Nope") is None
+
+
+def test_resolve_inv_result_prefers_explicit_key():
+    cfg = {"inv_st": AlertStatus.CLOSED, "inv_result": "False Positive"}
+    assert app._resolve_inv_result(cfg, AlertStatus.CLOSED) == InvestigationResult.FALSE_POSITIVE
+
+
+def test_resolve_inv_result_falls_back_to_fields():
+    cfg = {
+        "inv_st": AlertStatus.CLOSED,
+        "fields": [{"name": "investigationResult", "value": "True Positive"}],
+    }
+    assert app._resolve_inv_result(cfg, AlertStatus.CLOSED) == InvestigationResult.TRUE_POSITIVE
+
+
+def test_resolve_inv_result_missing_on_close_raises():
+    with pytest.raises(ValueError):
+        app._resolve_inv_result({"inv_st": AlertStatus.CLOSED}, AlertStatus.CLOSED)
+
+
+def test_resolve_inv_result_none_when_not_closing():
+    assert app._resolve_inv_result({"inv_st": AlertStatus.OPEN}, AlertStatus.OPEN) is None
+
+
+def test_v1_edit_status_sends_etag_and_status_in_correct_slots():
+    """Guards the ETag/status arg-inversion bug.
+
+    pytmv1 update_status signature is (alert_id, etag, status, inv_result,
+    inv_status). The ETag must be the 2nd positional arg and the AlertStatus the
+    ``status`` kwarg; the previous (alert_id, status, etag) order swapped them
+    and produced Vision One error 3090003.
+    """
+    inst = app.App.__new__(app.App)
+    inst.cache = {"WB-1": "SD-1"}
+    inst.v_client = MagicMock()
+    inst.v_client.alert.get.return_value = MagicMock(
+        result_code=ResultCode.SUCCESS,
+        response=MagicMock(etag="ETAG123"),
+    )
+    inst.v_client.alert.update_status.return_value = MagicMock(
+        result_code=ResultCode.SUCCESS
+    )
+    alert = MagicMock(id="WB-1")
+
+    inst._v1_edit_status(
+        alert, {"inv_st": AlertStatus.CLOSED, "inv_result": "True Positive"}
+    )
+
+    args, kwargs = inst.v_client.alert.update_status.call_args
+    assert args == ("WB-1", "ETAG123")
+    assert kwargs["status"] == AlertStatus.CLOSED
+    assert kwargs["inv_result"] == InvestigationResult.TRUE_POSITIVE
+
+
+def _user_field_app(username):
+    inst = app.App.__new__(app.App)
+    inst.cfg = SimpleNamespace(jira={"username": username, "token": "t", "url": "u"})
+    return inst
+
+
+def test_field_to_body_user_onprem_uses_name():
+    """On-premise (empty username -> Bearer auth) must send user by 'name'.
+
+    JIRA Server/DC rejects the Cloud-only 'accountId' key for user fields.
+    """
+    inst = _user_field_app("")
+    field = {"schema": {"type": "user"}, "key": "reporter"}
+    assert inst._field_to_body(field, "b.kozdruj") == {"name": "b.kozdruj"}
+
+
+def test_field_to_body_user_cloud_uses_accountid():
+    inst = _user_field_app("me@example.com")
+    field = {"schema": {"type": "user"}, "key": "reporter"}
+    assert inst._field_to_body(field, "5b10ac8d82e05b22cc7d4ef5") == {
+        "accountId": "5b10ac8d82e05b22cc7d4ef5"
+    }
+
+
+def test_fields_to_body_does_not_leak_across_alerts():
+    """Regression: a shallow copy let alert N's resolved values persist to N+1.
+
+    Resolving the shared `value: alert.id` must not mutate the config, so each
+    alert produces its own labels.
+    """
+    inst = app.App.__new__(app.App)
+    cfg_fields = [
+        {
+            "name": "labels",
+            "key": "labels",
+            "schema": {"type": "array", "items": "string"},
+            "value": ["alert.id"],
+        }
+    ]
+    first = inst._fields_to_body(SimpleNamespace(id="WB-1"), cfg_fields)
+    second = inst._fields_to_body(SimpleNamespace(id="WB-2"), cfg_fields)
+    assert first == {"labels": ["WB-1"]}
+    assert second == {"labels": ["WB-2"]}
+    # Config left untouched for the next alert.
+    assert cfg_fields[0]["value"] == ["alert.id"]
+
+
+def test_enum_val_renders_api_value():
+    assert app._enum_val(Severity.LOW) == "low"
+    assert app._enum_val("plain") == "plain"
+
+
+def test_format_ref_handles_string_and_hostinfo():
+    assert app._format_ref("1.2.3.4") == "1.2.3.4"
+    host = SimpleNamespace(name="srv-01", guid="g-1", ips=["10.0.0.1", "10.0.0.2"])
+    assert app._format_ref(host) == "srv-01 (g-1) - 10.0.0.1,10.0.0.2"
+    # Empty guid/ips are omitted (no trailing "()").
+    bare = SimpleNamespace(name="srv-02", guid="", ips=[])
+    assert app._format_ref(bare) == "srv-02"
+
+
+def test_dedupe_cap_dedupes_and_caps():
+    assert app._dedupe_cap(["a", "a", "b", "a"]) == ["a", "b"]
+    capped = app._dedupe_cap([str(i) for i in range(app._MAX_DESC_ITEMS + 5)])
+    assert len(capped) == app._MAX_DESC_ITEMS + 1
+    assert "more omitted" in capped[-1]


### PR DESCRIPTION
## Summary
The on-premise JIRA connector stopped working after `pytmv1` moved from 0.8.7 to
0.11.0 and the Vision One workbench alert status model changed. This restores it
to working parity (on-prem focus; Cloud path kept working).

## Fixes
- **Status update inverted ETag/status** -> Vision One error `3090003`. New
  `update_status` signature is `(alert_id, etag, status, inv_result, inv_status)`;
  the old positional call swapped ETag and status. Now uses keyword args.
- **"status not mapped" on close.** Sync now uses the alert **status**
  (`Open`/`In Progress`/`Closed`) instead of the deprecated investigation status
  (a closed alert reports a *result* like `True Positive`, which never matched a
  `Closed` mapping). Legacy config value `New` aliases to `Open`.
- **New optional `status[].inv_result`** (required to close an alert); falls back
  to an `investigationResult` entry under `fields`, which is no longer sent to
  JIRA as a field.
- **On-prem user fields.** `reporter`/`assignee` now use `name` on-premise and
  `accountId` on Cloud (JIRA Server/DC rejects `accountId`).
- **Field mapping leaked across alerts** (shallow copy) -> labels/priority frozen
  to the first alert. Now deep-copies before resolving `alert.*` values.
- **Enum display** `Severity.LOW` -> `low`; issue description de-duplicated and
  capped per section.
- Pinned `pytmv1~=0.11.0`.

## Docs & tests
- Rewrote README: auth table, supported-version matrix, full config reference,
  status-mapping guidance (must cover all workflow statuses), troubleshooting,
  changelog.
- Added `test_app.py` (13 regression tests).

## Verification
Verified end to end against on-premise JIRA 9.12 and a live Vision One tenant:
alert -> issue creation, and JIRA `Done` -> Vision One `Closed`
(`investigationResult: True Positive`) with the correct `If-Match` ETag.