### PR TITLE
fix(jira): immutable-release-safe latest download link

### DIFF
--- a/.github/workflows/jira-release.yml
+++ b/.github/workflows/jira-release.yml
@@ -1,9 +1,9 @@
 name: "JIRA Connector Release"
 
 # Triggered by pushing a tag matching jira-v* (e.g. jira-v1.0.0).
-# Packages only the JIRA/ directory into a tarball, publishes a versioned
-# GitHub release, and refreshes the moving "jira-latest" release/tag that the
-# README download link points to.
+# Packages only the JIRA/ directory into a tarball and publishes a versioned
+# GitHub release marked as "latest", so the README download link
+# (/releases/latest/download/...) always serves the newest JIRA build.
 on:
   push:
     tags:
@@ -41,15 +41,12 @@ jobs:
 
       - name: Publish versioned release
         run: |
+          # Mark this as the repo's latest release so the stable README link
+          # (/releases/latest/download/...) always serves the newest JIRA build.
+          # This replaces the old delete+recreate "jira-latest" moving tag, which
+          # is incompatible with the repo's immutable-releases setting (release
+          # tags cannot be deleted or reused once published).
           gh release create "${GITHUB_REF_NAME}" "${ASSET_NAME}" \
             --title "JIRA Connector v${{ steps.version.outputs.version }}" \
+            --latest \
             --notes "Trend Vision One JIRA connector v${{ steps.version.outputs.version }}. Download: ${ASSET_NAME}"
-
-      - name: Refresh jira-latest moving release
-        run: |
-          # Recreate the moving release so the stable README link always serves
-          # the newest JIRA build, independent of other connectors' releases.
-          gh release delete jira-latest --yes --cleanup-tag || true
-          gh release create jira-latest "${ASSET_NAME}" \
-            --title "JIRA Connector (latest: v${{ steps.version.outputs.version }})" \
-            --notes "Always points to the newest JIRA connector release (currently v${{ steps.version.outputs.version }})."

--- a/JIRA/README.md
+++ b/JIRA/README.md
@@ -58,7 +58,7 @@ API-token (basic) authentication.
 
 ### Download
 Latest packaged release (always points to the newest build):
-- [tm-v1-jira-connector.tar.gz](https://github.com/trendmicro/tm-v1-connectors/releases/download/jira-latest/tm-v1-jira-connector.tar.gz)
+- [tm-v1-jira-connector.tar.gz](https://github.com/trendmicro/tm-v1-connectors/releases/latest/download/tm-v1-jira-connector.tar.gz)
 
 Extract it:
 ```


### PR DESCRIPTION
## Problem
Old `jira-release.yml` deleted + recreated a moving `jira-latest` tag each publish. Repo has **immutable releases** enabled (since 7-7): release tags can't be deleted/reused. Recreate step fails, `jira-latest` release gets deleted but not rebuilt -> README download link dead.

## Fix
- Workflow publishes versioned release with `--latest`; drop broken delete+recreate step.
- README points to GitHub-native `/releases/latest/download/tm-v1-jira-connector.tar.gz` permalink. Stable URL, auto-resolves to newest, no delete/recreate.

## Note
- `jira-v1.0.1` already published (with the on-prem fix) and marked Latest, so the new permalink works immediately.
- Old `jira-latest` tag name permanently burned by immutable releases; not recoverable.